### PR TITLE
Solve an type error in ts declare file by using generics

### DIFF
--- a/lib/core.d.ts
+++ b/lib/core.d.ts
@@ -26,7 +26,7 @@ export = Core;
 declare class Core {
     constructor(config: Core.Config);
 
-    request(action: String, params: Object, options?: Object): Promise;
+    request<T>(action: String, params: Object, options?: Object): Promise<T>;
 }
 
 /*~ If you want to expose types from your module as well, you can


### PR DESCRIPTION
```
_@alicloud_pop-core@1.6.1@@alicloud/pop-core/lib/core.d.ts:29:64 - error TS2314: Generic type'Promise<T>' requires 1 type argument(s).
```
