### PR TITLE
fix: 改善类型定义, 避免 Core.ROAClient.ROAClient 这种实际上有问题但类型定义却通过的情况

### DIFF
--- a/lib/core.d.ts
+++ b/lib/core.d.ts
@@ -27,6 +27,8 @@ declare class Core {
     constructor(config: Core.Config);
 
     request<T>(action: String, params: Object, options?: Object): Promise<T>;
+    static ROAClient:typeof Core
+    static RPCClient:typeof Core
 }
 
 /*~ If you want to expose types from your module as well, you can

--- a/lib/core.d.ts
+++ b/lib/core.d.ts
@@ -23,12 +23,15 @@
 export = Core;
 
 /*~ Write your module's methods and properties in this class */
-declare class Core {
+declare class CoreConstructor {
     constructor(config: Core.Config);
 
     request<T>(action: String, params: Object, options?: Object): Promise<T>;
-    static ROAClient:typeof Core
-    static RPCClient:typeof Core
+}
+
+declare class Core extends CoreConstructor {
+    static ROAClient:typeof CoreConstructor
+    static RPCClient:typeof CoreConstructor
 }
 
 /*~ If you want to expose types from your module as well, you can


### PR DESCRIPTION
改善类型定义, 避免 `Core.ROAClient.ROAClient` 这种实际上有问题但类型定义却通过的情况.