### PR TITLE
fix: should change types file path in package.json after rename

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.7.3",
   "description": "AliCloud POP SDK core",
   "main": "index.js",
-  "types": "lib/core.d.ts",
+  "types": "lib/rpc.d.ts",
   "scripts": {
     "lint": "eslint --fix lib test",
     "test": "mocha -R spec test/*.test.js",


### PR DESCRIPTION
This commit https://github.com/aliyun/openapi-core-nodejs-sdk/commit/b6eccff426dbd08162dd130d053a806d387e8c0a breaks my typescript Node.js app. 

The reason is that you forgot to change types file path in `package.json` after rename `core.d.ts` to `rpc.d.ts`. So typescript cannot find declaration file.