### PR TITLE
fix: missing codes type definition in RPCClient.Config

### DIFF
--- a/lib/rpc.d.ts
+++ b/lib/rpc.d.ts
@@ -38,6 +38,7 @@ declare namespace RPCClient {
         apiVersion: string;
         accessKeyId: string;
         accessKeySecret: string;
+        codes?: (string | number)[];
         opts?: object;
     }
 }


### PR DESCRIPTION
I need to config return codes when construct RPCClient as defined in the code: https://github.com/aliyun/openapi-core-nodejs-sdk/blob/9737259906183dd7dc0a5f48e8dc8547af5f28f5/lib/rpc.js#L121-L127

But this `codes` config was not defined in `rpc.d.ts`, so I submit this PR to add `codes` type definition in that declaration file.