### PR TITLE
fix: add some missing definition in declaration file

### DIFF
--- a/lib/rpc.d.ts
+++ b/lib/rpc.d.ts
@@ -38,6 +38,8 @@ declare namespace RPCClient {
         apiVersion: string;
         accessKeyId: string;
         accessKeySecret: string;
+        securityToken?: string;
+        secretAccessKey?: string;
         codes?: (string | number)[];
         opts?: object;
     }


### PR DESCRIPTION
Sorry that I found `securityToken` missing in declaration file. To avoid submitting PR every time I found one missing, I went through the rpc.js file and found another missing parameter definition: `secretAccessKey`. Though it seems not quite that useful and might be a backward-compatible parameter, I still add it to the definition.

Another question, since you have rename `index.d.ts` to `rpc.d.ts`, how to add ROAClient typings into this project.