### PR TITLE
fix: CR 返回的 code 是 success 而不是 Success

### DIFF
--- a/lib/rpc.js
+++ b/lib/rpc.js
@@ -120,7 +120,7 @@ class RPCClient {
     this.securityToken = config.securityToken;
     this.verbose = verbose === true;
     // 非 codes 里的值，将抛出异常
-    this.codes = new Set([200, '200', 'OK', 'Success']);
+    this.codes = new Set([200, '200', 'OK', 'Success', 'success']);
     if (config.codes) {
       // 合并 codes
       for (var elem of config.codes) {


### PR DESCRIPTION
容器镜像服务的 code 是 `success`   https://help.aliyun.com/document_detail/145275.html 
这里只认为 `Success` 是正确的，所以容器镜像服务所有 API 调用都会报错。